### PR TITLE
Create pie chart component using mock data

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { AdoptionLineChart } from "@/components/charts/adoption-line-chart";
 import { PipelineBarChart } from "@/components/charts/pipeline-bar-chart";
+import { ShipMixPieChart } from "@/components/charts/ship-mix-pie-chart";
 import { TeamAdoptionChart } from "@/components/charts/team-adoption-chart";
 import { AutonomyGauge } from "@/components/charts/autonomy-gauge";
 import { ChartCard } from "@/components/dashboard/chart-card";
@@ -17,6 +18,7 @@ import {
   sparkB,
   sparkC,
   sparkD,
+  shipTypeMix,
 } from "@/lib/mock-data";
 
 const SPARKS = [sparkA, sparkB, sparkC, sparkD];
@@ -94,7 +96,7 @@ export default function DashboardPage() {
 
       <section
         id="pipeline"
-        className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2"
+        className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3"
       >
         <ChartCard
           title="Lifecycle pipeline"
@@ -107,6 +109,12 @@ export default function DashboardPage() {
           description="Percentage of AI toolchain usage per department"
         >
           <TeamAdoptionChart data={teamAdoption} />
+        </ChartCard>
+        <ChartCard
+          title="Ship mix"
+          description="Share of recent deliveries by delivery mode"
+        >
+          <ShipMixPieChart data={shipTypeMix} />
         </ChartCard>
       </section>
 

--- a/components/charts/ship-mix-pie-chart.tsx
+++ b/components/charts/ship-mix-pie-chart.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+import { CHART_COLORS, chartTooltipStyle } from "@/lib/chart-theme";
+
+const SLICE_COLORS = [
+  CHART_COLORS.primary,
+  CHART_COLORS.secondary,
+  "hsl(262, 70%, 58%)",
+  "hsl(38, 92%, 50%)",
+  "hsl(215, 16%, 47%)",
+];
+
+type Props = {
+  data: { label: string; value: number }[];
+};
+
+export function ShipMixPieChart({ data }: Props) {
+  const chartData = data.map((item) => ({
+    name: item.label,
+    value: item.value,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <PieChart>
+        <Pie
+          data={chartData}
+          cx="50%"
+          cy="50%"
+          innerRadius={56}
+          outerRadius={88}
+          paddingAngle={2}
+          dataKey="value"
+          stroke="none"
+        >
+          {chartData.map((_, index) => (
+            <Cell
+              key={`slice-${index}`}
+              fill={SLICE_COLORS[index % SLICE_COLORS.length]}
+            />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={chartTooltipStyle}
+          formatter={(value) => [`${value}%`, "Share"]}
+        />
+        <Legend
+          verticalAlign="bottom"
+          height={36}
+          iconType="circle"
+          iconSize={8}
+          formatter={(value) => (
+            <span className="text-xs text-muted-foreground">{value}</span>
+          )}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -55,6 +55,13 @@ export const ledger: ReadonlyArray<{
   { id: "HD-2168", title: "Hallmark design tokens v1.4",      practice: "Studio",    author: "Autonomous", at: "Sun",        kind: "autonomous", note: "53 component diffs proposed" },
 ];
 
+/** Share of recent ships by delivery mode (pie chart) */
+export const shipTypeMix = [
+  { label: "Autonomous", value: 71 },
+  { label: "Co-piloted", value: 18 },
+  { label: "Manual",     value: 11 },
+];
+
 export const practices = [
   { name: "Atelier",   focus: "Autonomous delivery",            count: 14, autonomy: 0.84 },
   { name: "Forge",     focus: "Platform engineering",           count: 11, autonomy: 0.62 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **HPRO-0002** by adding a pie chart to the dashboard that visualises the share of recent deliveries by delivery mode.

## Changes

- **`lib/mock-data.ts`** — Added `shipTypeMix` dataset (Autonomous / Co-piloted / Manual percentages).
- **`components/charts/ship-mix-pie-chart.tsx`** — New Recharts `PieChart` component styled to match existing dashboard charts (shared colours, tooltip, legend, donut layout).
- **`app/dashboard/page.tsx`** — Renders the pie chart in a new "Ship mix" `ChartCard` alongside the lifecycle pipeline and team adoption charts.

## Verification

- `npm run build` completes successfully with no type or lint errors.

Closes HPRO-0002
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ac35d32-ddce-47b3-be06-dcef3331b47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ac35d32-ddce-47b3-be06-dcef3331b47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

