### PR TITLE
Update mock data to support pie chart visualization

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { AdoptionLineChart } from "@/components/charts/adoption-line-chart";
+import { DeliveryMixPieChart } from "@/components/charts/delivery-mix-pie-chart";
 import { PipelineBarChart } from "@/components/charts/pipeline-bar-chart";
 import { TeamAdoptionChart } from "@/components/charts/team-adoption-chart";
 import { AutonomyGauge } from "@/components/charts/autonomy-gauge";
@@ -8,6 +9,7 @@ import { StatCard } from "@/components/dashboard/stat-card";
 import { CHART_COLORS } from "@/lib/chart-theme";
 import {
   adoptionCurve,
+  deliveryMix,
   lifecyclePipeline,
   teamAdoption,
   kpis,
@@ -94,7 +96,7 @@ export default function DashboardPage() {
 
       <section
         id="pipeline"
-        className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2"
+        className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3"
       >
         <ChartCard
           title="Lifecycle pipeline"
@@ -107,6 +109,12 @@ export default function DashboardPage() {
           description="Percentage of AI toolchain usage per department"
         >
           <TeamAdoptionChart data={teamAdoption} />
+        </ChartCard>
+        <ChartCard
+          title="Delivery mix"
+          description="47 May ships by execution mode"
+        >
+          <DeliveryMixPieChart data={deliveryMix} />
         </ChartCard>
       </section>
 

--- a/components/charts/delivery-mix-pie-chart.tsx
+++ b/components/charts/delivery-mix-pie-chart.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { CHART_COLORS, chartTooltipStyle } from "@/lib/chart-theme";
+
+const SLICE_COLORS = [
+  CHART_COLORS.primary,
+  "hsl(215, 16%, 47%)",
+  "hsl(38, 92%, 50%)",
+];
+
+type Props = {
+  data: { label: string; count: number; share: number }[];
+};
+
+export function DeliveryMixPieChart({ data }: Props) {
+  const chartData = data.map((slice) => ({
+    name: slice.label,
+    value: slice.count,
+    share: slice.share,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <PieChart>
+        <Pie
+          data={chartData}
+          dataKey="value"
+          nameKey="name"
+          cx="50%"
+          cy="50%"
+          innerRadius={56}
+          outerRadius={88}
+          paddingAngle={2}
+          stroke="none"
+        >
+          {chartData.map((_, index) => (
+            <Cell key={chartData[index].name} fill={SLICE_COLORS[index % SLICE_COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={chartTooltipStyle}
+          formatter={(value, _name, item) => {
+            const share = item.payload?.share as number | undefined;
+            const pct = share != null ? `${Math.round(share * 100)}%` : "";
+            return [`${value} ships (${pct})`, item.payload?.name];
+          }}
+        />
+        <Legend
+          verticalAlign="bottom"
+          height={36}
+          formatter={(value) => (
+            <span className="text-xs text-muted-foreground">{value}</span>
+          )}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -30,6 +30,13 @@ export const teamAdoption = [
   { team: "Finance",     value: 41 },
 ];
 
+/** May delivery mix by execution mode — feeds the dashboard pie chart. */
+export const deliveryMix = [
+  { label: "Autonomous", count: 29, share: 0.62 },
+  { label: "Co-piloted", count: 11, share: 0.24 },
+  { label: "Manual",     count: 7,  share: 0.14 },
+];
+
 export const kpis = [
   { label: "Autonomy Index",   value: "87",     unit: "/100",   delta: "+12",   trend: "up"   as const, foot: "vs. Q1 — across 47 practices" },
   { label: "Cycle Time",       value: "3.2",    unit: "days",   delta: "−10.8", trend: "down" as const, foot: "down from 14d, twelve months ago" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `deliveryMix` mock data for the dashboard pie chart and wires it into a new **Delivery mix** chart on the dashboard.

**Refs:** HPRO-0004

## Changes

- **`lib/mock-data.ts`** — New `deliveryMix` export with `label`, `count`, and `share` fields for May ships by execution mode (Autonomous, Co-piloted, Manual). Totals align with the existing Autonomous Ships KPI (47/mo).
- **`components/charts/delivery-mix-pie-chart.tsx`** — New recharts pie chart component that reads from `deliveryMix`.
- **`app/dashboard/page.tsx`** — Adds the Delivery mix chart to the pipeline section (now a 3-column grid on large screens).

## Acceptance criteria

- [x] Mock data includes relevant fields for pie chart (`label`, `count`, `share`)
- [x] Pie chart displays accurate data from mock data
- [x] No existing mock data is adversely affected (all prior exports unchanged)

## Verification

- `npm run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8580c59-ee3a-4e57-9001-92a203ddfe3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8580c59-ee3a-4e57-9001-92a203ddfe3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

