### PR TITLE
Integrate pie chart into existing dashboard layout

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,12 +2,14 @@ import Link from "next/link";
 import { AdoptionLineChart } from "@/components/charts/adoption-line-chart";
 import { PipelineBarChart } from "@/components/charts/pipeline-bar-chart";
 import { TeamAdoptionChart } from "@/components/charts/team-adoption-chart";
+import { PieChart } from "@/components/charts/pie-chart";
 import { AutonomyGauge } from "@/components/charts/autonomy-gauge";
 import { ChartCard } from "@/components/dashboard/chart-card";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { CHART_COLORS } from "@/lib/chart-theme";
 import {
   adoptionCurve,
+  deliveryMix,
   lifecyclePipeline,
   teamAdoption,
   kpis,
@@ -94,7 +96,7 @@ export default function DashboardPage() {
 
       <section
         id="pipeline"
-        className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2"
+        className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3"
       >
         <ChartCard
           title="Lifecycle pipeline"
@@ -107,6 +109,12 @@ export default function DashboardPage() {
           description="Percentage of AI toolchain usage per department"
         >
           <TeamAdoptionChart data={teamAdoption} />
+        </ChartCard>
+        <ChartCard
+          title="Delivery mix"
+          description="Share of ships by delivery mode this quarter"
+        >
+          <PieChart data={deliveryMix} />
         </ChartCard>
       </section>
 

--- a/components/charts/pie-chart.tsx
+++ b/components/charts/pie-chart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart as RechartsPieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+import { CHART_COLORS, chartTooltipStyle } from "@/lib/chart-theme";
+
+const SLICE_COLORS = [
+  CHART_COLORS.primary,
+  CHART_COLORS.secondary,
+  "hsl(38, 92%, 50%)",
+];
+
+type Props = {
+  data: { name: string; value: number }[];
+};
+
+export function PieChart({ data }: Props) {
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <RechartsPieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="45%"
+          innerRadius={56}
+          outerRadius={88}
+          paddingAngle={2}
+          dataKey="value"
+          nameKey="name"
+          stroke="none"
+        >
+          {data.map((entry, index) => (
+            <Cell
+              key={entry.name}
+              fill={SLICE_COLORS[index % SLICE_COLORS.length]}
+            />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={chartTooltipStyle}
+          formatter={(value) => [`${value}%`, "Share"]}
+        />
+        <Legend
+          verticalAlign="bottom"
+          iconType="circle"
+          iconSize={8}
+          formatter={(value) => (
+            <span className="text-sm text-muted-foreground">{value}</span>
+          )}
+        />
+      </RechartsPieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -21,6 +21,12 @@ export const lifecyclePipeline = [
   { phase: "Steward",   count: 9,  share: 0.06 },
 ];
 
+export const deliveryMix = [
+  { name: "Autonomous", value: 62 },
+  { name: "Co-piloted", value: 28 },
+  { name: "Manual",     value: 10 },
+];
+
 export const teamAdoption = [
   { team: "Engineering", value: 92 },
   { team: "Research",    value: 88 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates the pie chart component into the dashboard pipeline charts section, displaying a **Delivery mix** breakdown (Autonomous / Co-piloted / Manual) alongside the existing lifecycle pipeline and team adoption charts.

Closes **HPRO-0003**.

## Changes

- Added `PieChart` component (`components/charts/pie-chart.tsx`) using recharts with donut styling, tooltip, and legend — consistent with existing chart components
- Added `deliveryMix` mock data in `lib/mock-data.ts`
- Wired the pie chart into `app/dashboard/page.tsx` within the pipeline section
- Extended the charts grid to `xl:grid-cols-3` so all three charts sit in one row on wide screens and stack responsively on smaller breakpoints

## Verification

- `npm run build` completes successfully with no type or lint errors
- Dashboard renders the pie chart without errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0545f7f6-bfda-429a-91bb-3ac075ad8afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0545f7f6-bfda-429a-91bb-3ac075ad8afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

